### PR TITLE
Update header buttons to brand orange and add navigation

### DIFF
--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -103,9 +103,7 @@ export function Header() {
                     {unreadCount}
                   </span>
                 )}
-                <span className="ml-2">
-                  Notifications
-                </span>
+                <span className="ml-2">Notifications</span>
               </Button>
 
               {/* Notifications Dropdown */}
@@ -145,14 +143,16 @@ export function Header() {
                           className={`p-3 border-b border-gray-100 last:border-b-0 cursor-pointer hover:bg-gray-50 ${!notification.read ? "bg-blue-50" : ""}`}
                           onClick={() => {
                             // Navigate based on notification type
-                            if (notification.title.includes('Supplier')) {
-                              window.location.href = '/suppliers';
-                            } else if (notification.title.includes('Group Order')) {
-                              window.location.href = '/group-orders';
-                            } else if (notification.title.includes('Payment')) {
-                              window.location.href = '/dashboard';
+                            if (notification.title.includes("Supplier")) {
+                              window.location.href = "/suppliers";
+                            } else if (
+                              notification.title.includes("Group Order")
+                            ) {
+                              window.location.href = "/group-orders";
+                            } else if (notification.title.includes("Payment")) {
+                              window.location.href = "/dashboard";
                             } else {
-                              window.location.href = '/dashboard';
+                              window.location.href = "/dashboard";
                             }
                           }}
                         >
@@ -334,14 +334,18 @@ export function Header() {
                               className={`p-2 border-b border-gray-100 last:border-b-0 cursor-pointer hover:bg-gray-50 ${!notification.read ? "bg-blue-50" : ""}`}
                               onClick={() => {
                                 // Navigate based on notification type
-                                if (notification.title.includes('Supplier')) {
-                                  window.location.href = '/suppliers';
-                                } else if (notification.title.includes('Group Order')) {
-                                  window.location.href = '/group-orders';
-                                } else if (notification.title.includes('Payment')) {
-                                  window.location.href = '/dashboard';
+                                if (notification.title.includes("Supplier")) {
+                                  window.location.href = "/suppliers";
+                                } else if (
+                                  notification.title.includes("Group Order")
+                                ) {
+                                  window.location.href = "/group-orders";
+                                } else if (
+                                  notification.title.includes("Payment")
+                                ) {
+                                  window.location.href = "/dashboard";
                                 } else {
-                                  window.location.href = '/dashboard';
+                                  window.location.href = "/dashboard";
                                 }
                               }}
                             >

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -103,7 +103,7 @@ export function Header() {
                     {unreadCount}
                   </span>
                 )}
-                <span className="ml-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                <span className="ml-2">
                   Notifications
                 </span>
               </Button>
@@ -142,7 +142,19 @@ export function Header() {
                       notifications.map((notification) => (
                         <div
                           key={notification.id}
-                          className={`p-3 border-b border-gray-100 last:border-b-0 ${!notification.read ? "bg-blue-50" : ""}`}
+                          className={`p-3 border-b border-gray-100 last:border-b-0 cursor-pointer hover:bg-gray-50 ${!notification.read ? "bg-blue-50" : ""}`}
+                          onClick={() => {
+                            // Navigate based on notification type
+                            if (notification.title.includes('Supplier')) {
+                              window.location.href = '/suppliers';
+                            } else if (notification.title.includes('Group Order')) {
+                              window.location.href = '/group-orders';
+                            } else if (notification.title.includes('Payment')) {
+                              window.location.href = '/dashboard';
+                            } else {
+                              window.location.href = '/dashboard';
+                            }
+                          }}
                         >
                           <div className="flex items-start justify-between">
                             <div className="flex-1">
@@ -319,7 +331,19 @@ export function Header() {
                           notifications.slice(0, 3).map((notification) => (
                             <div
                               key={notification.id}
-                              className={`p-2 border-b border-gray-100 last:border-b-0 ${!notification.read ? "bg-blue-50" : ""}`}
+                              className={`p-2 border-b border-gray-100 last:border-b-0 cursor-pointer hover:bg-gray-50 ${!notification.read ? "bg-blue-50" : ""}`}
+                              onClick={() => {
+                                // Navigate based on notification type
+                                if (notification.title.includes('Supplier')) {
+                                  window.location.href = '/suppliers';
+                                } else if (notification.title.includes('Group Order')) {
+                                  window.location.href = '/group-orders';
+                                } else if (notification.title.includes('Payment')) {
+                                  window.location.href = '/dashboard';
+                                } else {
+                                  window.location.href = '/dashboard';
+                                }
+                              }}
                             >
                               <h4 className="text-sm font-medium text-gray-900">
                                 {notification.title}

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -76,7 +76,7 @@ export function Header() {
             <Button
               variant="outline"
               size="sm"
-              className="bg-white text-gray-600 hover:bg-gray-50 border border-gray-200"
+              className="bg-brand-orange hover:bg-brand-orange-dark text-white"
               onClick={async () => {
                 try {
                   const response = await fetch("/api/demo");
@@ -95,7 +95,7 @@ export function Header() {
               <Button
                 variant="ghost"
                 size="sm"
-                className="bg-white text-gray-600 hover:bg-gray-50 border border-gray-200 relative"
+                className="bg-brand-orange hover:bg-brand-orange-dark text-white relative"
               >
                 <Bell className="h-4 w-4" />
                 {unreadCount > 0 && (
@@ -245,7 +245,7 @@ export function Header() {
                 <Button
                   variant="outline"
                   size="sm"
-                  className="bg-white text-gray-600 hover:bg-gray-50 border border-gray-200 w-full justify-start"
+                  className="bg-brand-orange hover:bg-brand-orange-dark text-white w-full justify-start"
                   onClick={async () => {
                     try {
                       const response = await fetch("/api/demo");
@@ -264,7 +264,7 @@ export function Header() {
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="bg-white text-gray-600 hover:bg-gray-50 border border-gray-200 w-full justify-start relative"
+                    className="bg-brand-orange hover:bg-brand-orange-dark text-white w-full justify-start relative"
                     onClick={(e) => {
                       e.stopPropagation();
                       const dropdown = e.currentTarget

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -65,9 +65,7 @@ export default function Index() {
                       }
                     }}
                   >
-                    <span>
-                      Watch Demo
-                    </span>
+                    <span>Watch Demo</span>
                   </Button>
                 </div>
               </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -53,7 +53,7 @@ export default function Index() {
                   <Button
                     variant="ghost"
                     size="lg"
-                    className="bg-white text-gray-600 hover:bg-gray-50 border border-gray-200"
+                    className="bg-brand-orange hover:bg-brand-orange-dark text-white"
                     onClick={async () => {
                       try {
                         const response = await fetch("/api/demo");

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -65,7 +65,7 @@ export default function Index() {
                       }
                     }}
                   >
-                    <span className="opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                    <span>
                       Watch Demo
                     </span>
                   </Button>


### PR DESCRIPTION
## Purpose

The user requested to update the watch demo and notifications buttons to match the "Find Suppliers Now" button color (brand orange). They also wanted these buttons to be visible without requiring hover interaction and requested that clicking on notification content should navigate to the respective tasks/pages.

## Code changes

- **Button styling**: Changed watch demo and notifications buttons from white/gray color scheme to brand orange (`bg-brand-orange hover:bg-brand-orange-dark text-white`)
- **Visibility improvements**: Removed opacity transitions that required hover to show button text - buttons are now always visible
- **Navigation functionality**: Added click handlers to notification items that route users to relevant pages based on notification type:
  - Supplier notifications → `/suppliers`
  - Group Order notifications → `/group-orders` 
  - Payment notifications → `/dashboard`
  - Default fallback → `/dashboard`
- **Interactive styling**: Added cursor pointer and hover effects to notification items for better UX

Changes applied to both desktop and mobile header layouts in `Header.tsx` and the main page watch demo button in `Index.tsx`.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/af162cc9fd5b487394c1b5bdc45c7349/glow-realm)

👀 [Preview Link](https://af162cc9fd5b487394c1b5bdc45c7349-glow-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>af162cc9fd5b487394c1b5bdc45c7349</projectId>-->
<!--<branchName>glow-realm</branchName>-->